### PR TITLE
fix: correctly implement error interfaces on wrapped errors

### DIFF
--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -65,3 +65,29 @@ func Test_retry(t *testing.T) {
 		})
 	}
 }
+
+func Test_errors(t *testing.T) {
+	e := errors.New("xyz")
+
+	if !errors.Is(ExpectedError(e), e) {
+		t.Fatal("expected error should wrap errors")
+	}
+
+	if !errors.Is(UnexpectedError(e), e) {
+		t.Fatal("unexpected error should wrap errors")
+	}
+
+	errSet := ErrorSet{}
+	errSet.Append(e)
+
+	if !errors.Is(&errSet, e) {
+		t.Fatal("error set should wrap errors")
+	}
+
+	errSet = ErrorSet{}
+	errSet.Append(UnexpectedError(e))
+
+	if !errors.Is(&errSet, e) {
+		t.Fatal("error set should wrap errors")
+	}
+}


### PR DESCRIPTION
There were two problems:

* `ExpectedError` and `UnexpectedError` should unwrap themselves
* `ErrorSet` should support equivalency check when there's a single
error inside.

This fixes the scenario of matching an error from a retry loop (in case if
just a single error was encountered).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>