### PR TITLE
feat: add support for `context.Context` in Retry

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-09-01T21:14:08Z by kres ee90a80-dirty.
+# Generated on 2021-01-18T14:11:16Z by kres latest.
 
 kind: pipeline
 type: kubernetes
@@ -132,7 +132,6 @@ services:
   - --dns=8.8.4.4
   - --mtu=1500
   - --log-level=error
-  - --insecure-registry=http://registry.ci.svc:5000
   privileged: true
   volumes:
   - name: outer-docker-socket

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-09-01T21:14:08Z by kres ee90a80-dirty.
+# Generated on 2021-01-18T14:11:16Z by kres latest.
 
 
 # options for analysis running
@@ -125,6 +125,9 @@ linters:
     - gomnd
     - goerr113
     - nestif
+    - wrapcheck
+    - paralleltest
+    - exhaustivestruct
   disable-all: false
   fast: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# syntax = docker/dockerfile-upstream:1.1.7-experimental
+# syntax = docker/dockerfile-upstream:1.2.0-labs
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-09-01T21:14:08Z by kres ee90a80-dirty.
+# Generated on 2021-01-18T14:11:16Z by kres latest.
 
 ARG TOOLCHAIN
 
@@ -24,7 +24,7 @@ FROM toolchain AS tools
 ENV GO111MODULE on
 ENV CGO_ENABLED 0
 ENV GOPATH /go
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.30.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.33.0
 ARG GOFUMPT_VERSION
 RUN cd $(mktemp -d) \
 	&& go mod init tmp \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2020-09-21T13:20:49Z by kres 7e146df-dirty.
+# Generated on 2021-01-18T14:11:16Z by kres latest.
 
 # common variables
 
@@ -8,13 +8,13 @@ SHA := $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG := $(shell git describe --tag --always --dirty)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
-REGISTRY ?= docker.io
-USERNAME ?= autonomy
+REGISTRY ?= ghcr.io
+USERNAME ?= talos-systems
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
 GO_VERSION ?= 1.14
 TESTPKGS ?= ./...
-KRES_IMAGE ?= autonomy/kres:latest
+KRES_IMAGE ?= ghcr.io/talos-systems/kres:latest
 
 # docker build settings
 

--- a/retry/options.go
+++ b/retry/options.go
@@ -10,9 +10,10 @@ import (
 
 // Options is the functional options struct.
 type Options struct {
-	Units     time.Duration
-	Jitter    time.Duration
-	LogErrors bool
+	Units          time.Duration
+	Jitter         time.Duration
+	AttemptTimeout time.Duration
+	LogErrors      bool
 }
 
 // Option is the functional option func.
@@ -36,6 +37,13 @@ func WithJitter(o time.Duration) Option {
 func WithErrorLogging(enable bool) Option {
 	return func(args *Options) {
 		args.LogErrors = enable
+	}
+}
+
+// WithAttemptTimeout sets timeout for each retry attempt.
+func WithAttemptTimeout(o time.Duration) Option {
+	return func(args *Options) {
+		args.AttemptTimeout = o
 	}
 }
 


### PR DESCRIPTION
Existing function `Retry` is maintained with the same API to preserve
backwards compatibility.

New function `RetryWithContext` accepts a context and delivers it to the
retryable function. Each retry attempt can be limited by timeout (via
context, `WithAttemptTimeout`).

Garbage-collected channel `C` which wasn't used.

Replaced stop channel delivery with `close(ch)` to avoid having a
channel with a single entry.

Removed `time.After()` as it leaks the object until timer fires.

Fixes #2

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>