### PR TITLE
fix: implement `errors.Is` for all errors in the set

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -91,7 +91,13 @@ func (e *ErrorSet) Is(err error) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	return len(e.errs) == 1 && errors.Is(e.errs[0], err)
+	for _, ee := range e.errs {
+		if errors.Is(ee, err) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // TimeoutError represents a timeout error.

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -130,6 +130,12 @@ func Test_errors(t *testing.T) {
 		t.Fatal("error set should wrap errors")
 	}
 
+	errSet.Append(errors.New("foo"))
+
+	if !errors.Is(&errSet, e) {
+		t.Fatal("error set should wrap errors")
+	}
+
 	errSet = ErrorSet{}
 	errSet.Append(UnexpectedError(e))
 


### PR DESCRIPTION
Previously it matched only a single error if the set consists of a
single error. But the retry might fail many times on some expected error
followed by unexpected error which we want to test for with 'errors.Is'.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>